### PR TITLE
Add Grok to AI agent examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # DoorDash CLI
 
-DoorDash CLI (`dd-cli`) is a terminal tool for ordering from DoorDash — search restaurants and stores, browse menus, build a cart, reorder a past order, and preview or check out — all from the command line. It's built to be driven directly by a human, or called by AI agents with shell access (Claude Code, Cursor, Codex, etc.) so they can complete ordering tasks on your behalf.
+DoorDash CLI (`dd-cli`) is a terminal tool for ordering from DoorDash — search restaurants and stores, browse menus, build a cart, reorder a past order, and preview or check out — all from the command line. It's built to be driven directly by a human, or called by AI agents with shell access (Claude Code, Cursor, Codex, Grok, etc.) so they can complete ordering tasks on your behalf.
 
 > Waitlist-only. Full functionality requires an approved account. Join the waitlist here: https://forms.gle/gvCQZvu9C1EKA6aM6
 


### PR DESCRIPTION
## Summary
- Add Grok to the list of AI coding agents that can drive dd-cli from the shell.

## Testing
- Ran `git diff --check`.