### PR TITLE
Add setup script, agent skill, and updated README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,17 @@ DoorDash CLI (`dd-cli`) is a terminal tool for ordering from DoorDash — search
 
 Currently supported: **macOS, Apple Silicon (M1/M2/M3/M4)**.
 
-## Download
+## Quick Setup
+
+Run this one-liner to download, verify, and install the latest release:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/doordash-oss/doordash-cli/main/setup.sh | bash
+```
+
+The script auto-detects your OS and architecture, verifies the SHA256 checksum, and installs the binary to `~/.local/bin/dd-cli`.
+
+## Manual Download
 
 1. Go to the [Releases page](https://github.com/doordash-oss/doordash-cli/releases) and open the latest release.
 2. Download the `dd-cli-v<version>-darwin-arm64.tar.gz` asset.
@@ -22,6 +32,20 @@ To compute the checksum of your download:
 ```bash
 shasum -a 256 dd-cli-v<version>-darwin-arm64.tar.gz
 ```
+
+## Using with AI Agents
+
+DoorDash CLI works with Claude Code, Cursor, Codex, and other terminal-based AI agents. Copy the skill file from [`skills/dd-cli-usage/SKILL.md`](skills/dd-cli-usage/SKILL.md) to your agent's skill directory:
+
+| Agent      | Skill directory                  |
+|------------|----------------------------------|
+| Claude Code | `~/.claude/skills/dd-cli-usage/` |
+| Cursor      | `~/.cursor/skills/dd-cli-usage/` |
+| Codex       | `~/.agents/skills/dd-cli-usage/` |
+| Gemini CLI  | `~/.gemini/config/skills/dd-cli-usage/` |
+| OpenClaw    | `~/.openclaw/skills/dd-cli-usage/` |
+
+Once installed, your agent automatically knows how to use `dd-cli` — no priming needed.
 
 ## Try it
 

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+# setup.sh -- One-command installer for DoorDash CLI.
+#
+# Usage:
+#   curl -fsSL https://raw.githubusercontent.com/doordash-oss/doordash-cli/main/setup.sh | bash
+#
+# What it does:
+#   1. Detects your OS and architecture
+#   2. Fetches the latest release from GitHub
+#   3. Downloads the matching tarball
+#   4. Verifies the SHA256 checksum published in the release notes
+#   5. Extracts and runs the bundled install.sh
+#   6. Cleans up temporary files
+set -euo pipefail
+
+REPO="doordash-oss/doordash-cli"
+API="https://api.github.com/repos/$REPO/releases/latest"
+
+# -- Detect OS and architecture -----------------------------------------------
+
+detect_platform() {
+  local os arch
+
+  case "$(uname -s)" in
+    Darwin)  os="darwin"  ;;
+    Linux)   os="linux"   ;;
+    MINGW*|MSYS*|CYGWIN*) os="windows" ;;
+    *)
+      echo "Error: unsupported operating system '$(uname -s)'." >&2
+      exit 1
+      ;;
+  esac
+
+  case "$(uname -m)" in
+    arm64|aarch64)  arch="arm64"  ;;
+    x86_64|amd64)   arch="amd64"  ;;
+    *)
+      echo "Error: unsupported architecture '$(uname -m)'." >&2
+      exit 1
+      ;;
+  esac
+
+  echo "${os}-${arch}"
+}
+
+PLATFORM=$(detect_platform)
+echo "Detected platform: $PLATFORM"
+
+# -- Preflight ----------------------------------------------------------------
+
+if ! command -v curl >/dev/null 2>&1; then
+  echo "Error: curl is required but not found." >&2
+  exit 1
+fi
+
+# -- Fetch latest release metadata --------------------------------------------
+
+echo "Fetching latest release info..."
+RELEASE_JSON=$(curl -fsSL "$API")
+
+TAG=$(printf '%s' "$RELEASE_JSON" | grep '"tag_name"' | head -1 | sed 's/.*"tag_name" *: *"\([^"]*\)".*/\1/')
+VERSION="${TAG#v}"
+
+if [ -z "$VERSION" ]; then
+  echo "Error: could not determine latest version." >&2
+  exit 1
+fi
+
+ASSET_NAME="dd-cli-v${VERSION}-${PLATFORM}.tar.gz"
+DOWNLOAD_URL="https://github.com/$REPO/releases/download/$TAG/$ASSET_NAME"
+
+echo "Latest release: $TAG"
+
+# -- Check that an asset exists for this platform -----------------------------
+
+if ! printf '%s' "$RELEASE_JSON" | grep -q "$ASSET_NAME"; then
+  echo "Error: no release asset found for your platform ($PLATFORM)." >&2
+  echo "       Available assets can be viewed at:" >&2
+  echo "       https://github.com/$REPO/releases/tag/$TAG" >&2
+  exit 1
+fi
+
+# -- Extract expected checksum from release body ------------------------------
+
+EXPECTED_SHA=$(printf '%s' "$RELEASE_JSON" \
+  | grep -i "SHA256" \
+  | grep -oE '[0-9a-f]{64}' \
+  | head -1)
+
+if [ -z "$EXPECTED_SHA" ]; then
+  echo "Warning: could not extract SHA256 checksum from release notes."
+  echo "         The download will proceed but cannot be verified."
+fi
+
+# -- Download -----------------------------------------------------------------
+
+TMPDIR_SETUP=$(mktemp -d)
+trap 'rm -rf "$TMPDIR_SETUP"' EXIT
+
+TARBALL="$TMPDIR_SETUP/$ASSET_NAME"
+
+echo "Downloading $ASSET_NAME..."
+curl -fSL --progress-bar -o "$TARBALL" "$DOWNLOAD_URL"
+
+# -- Verify checksum ----------------------------------------------------------
+
+if [ -n "${EXPECTED_SHA:-}" ]; then
+  if command -v shasum >/dev/null 2>&1; then
+    ACTUAL_SHA=$(shasum -a 256 "$TARBALL" | awk '{print $1}')
+  elif command -v sha256sum >/dev/null 2>&1; then
+    ACTUAL_SHA=$(sha256sum "$TARBALL" | awk '{print $1}')
+  else
+    echo "Warning: neither shasum nor sha256sum found; skipping checksum verification."
+    ACTUAL_SHA=""
+  fi
+
+  if [ -n "$ACTUAL_SHA" ] && [ "$ACTUAL_SHA" != "$EXPECTED_SHA" ]; then
+    echo "Error: checksum mismatch!" >&2
+    echo "  Expected: $EXPECTED_SHA" >&2
+    echo "  Got:      $ACTUAL_SHA" >&2
+    echo "The downloaded file may be corrupt or tampered with. Aborting." >&2
+    exit 1
+  fi
+
+  [ -n "$ACTUAL_SHA" ] && echo "Checksum verified."
+fi
+
+# -- Extract & install --------------------------------------------------------
+
+echo "Extracting..."
+tar -xzf "$TARBALL" -C "$TMPDIR_SETUP"
+
+EXTRACTED="$TMPDIR_SETUP/dd-cli-v${VERSION}-${PLATFORM}"
+
+if [ ! -f "$EXTRACTED/install.sh" ]; then
+  echo "Error: install.sh not found in extracted archive." >&2
+  exit 1
+fi
+
+bash "$EXTRACTED/install.sh" <<< "6"
+
+# -- PATH hint ----------------------------------------------------------------
+
+if ! command -v dd-cli >/dev/null 2>&1; then
+  SHELL_NAME=$(basename "$SHELL")
+  case "$SHELL_NAME" in
+    zsh)  RC_FILE=".zshrc"    ;;
+    bash) RC_FILE=".bashrc"   ;;
+    *)    RC_FILE=".profile"  ;;
+  esac
+
+  echo ""
+  echo "Note: ~/.local/bin is not on your PATH."
+  echo "Add it by running:"
+  echo ""
+  echo "  echo 'export PATH=\"\$HOME/.local/bin:\$PATH\"' >> ~/$RC_FILE && source ~/$RC_FILE"
+  echo ""
+fi
+
+echo ""
+echo "Setup complete! Run 'dd-cli login' to sign in, then 'dd-cli --help' to explore."

--- a/skills/dd-cli-usage/SKILL.md
+++ b/skills/dd-cli-usage/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: dd-cli-usage
+description: >-
+  Use DoorDash CLI (dd-cli) to order food, groceries, or retail items from local businesses
+  via DoorDash.
+---
+
+# DoorDash CLI
+
+`dd-cli` is available on PATH. Its commands form a tree of command groups terminating in leaf commands.
+
+"DoorDash CLI" and `dd-cli` refer to the same tool — the command you run is `dd-cli`. Treat either name from the user as interchangeable.
+
+Use `--help` / `-h` to navigate on demand — start at the root and follow only
+the path relevant to the user's request:
+
+```
+dd-cli --help               # root: all commands and groups
+dd-cli cart --help          # group: lists subcommands
+dd-cli cart add-items --help  # leaf: options and usage
+```
+
+Do not pre-map the full tree. Drill deeper only when you need the next level.


### PR DESCRIPTION
## Summary

Three additions to improve the getting-started experience:

### 1. `setup.sh` -- one-command installer

```bash
curl -fsSL https://raw.githubusercontent.com/doordash-oss/doordash-cli/main/setup.sh | bash
```

- Auto-detects OS (`Darwin`/`Linux`/`Windows`) and arch (`arm64`/`amd64`)
- Fetches the latest release via the GitHub API
- Downloads the matching tarball
- Verifies the SHA256 checksum from the release notes (`shasum` on macOS, `sha256sum` on Linux)
- Runs the bundled `install.sh`
- Provides a shell-aware PATH hint (`.zshrc`/`.bashrc`/`.profile`)

### 2. `skills/dd-cli-usage/SKILL.md` -- agent skill

The same skill file that ships inside the release tarball, now version-controlled in the repo. Agents can reference it directly from the repo or copy it into their skill directories.

### 3. Updated `README.md`

- Added **Quick Setup** section with the curl one-liner (above the manual steps)
- Added **Using with AI Agents** section with a table of skill directories for Claude Code, Cursor, Codex, Gemini CLI, and OpenClaw
- Renamed old "Download" to "Manual Download"

## Testing

Tested end-to-end on macOS Apple Silicon against v0.2.0:

```
Detected platform: darwin-arm64
Fetching latest release info...
Latest release: v0.2.0
Downloading dd-cli-v0.2.0-darwin-arm64.tar.gz...
Checksum verified.
Extracting...
Installing dd-cli-v0.2.0-darwin-arm64 to ~/.local/bin/dd-cli ...
Setup complete!
```