### PR TITLE
Add reproducible Linux release repackager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/build/
+/dist/
+/*.spec

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /build/
 /dist/
 /*.spec
+__pycache__/
+*.py[cod]

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ shasum -a 256 dd-cli-v<version>-darwin-arm64.tar.gz
 
 ## Linux rebuild
 
-On a 64-bit glibc Linux host (x86_64 or aarch64), run:
+On a 64-bit glibc 2.17+ Linux host (x86_64 or aarch64), run:
 
 ```bash
 bash scripts/rebuild-linux.sh
@@ -58,9 +58,10 @@ bash scripts/rebuild-linux.sh
 The script selects the latest official macOS ARM64 release, verifies its
 published SHA256 digest, extracts the architecture-neutral Python package,
 recreates its exact dependency set on a matching Linux Python runtime, builds
-a native executable, exercises its command surface and Linux Secret Service
-credential path, and writes a binary plus installable archive under `dist/`.
-To rebuild a specific release, pass its version:
+a native executable against the manylinux2014 baseline, audits its bundled ELF
+libraries, exercises its command surface and Linux Secret Service credential
+path, and writes a binary plus installable archive under `dist/`. To rebuild a
+specific release, pass its version:
 
 ```bash
 bash scripts/rebuild-linux.sh 0.2.1

--- a/README.md
+++ b/README.md
@@ -72,6 +72,37 @@ keychain (for example GNOME Keyring). This matches the official CLI's rule that
 OAuth credentials must use an operating-system keychain; no plaintext token
 fallback is introduced.
 
+### Headless SSH sign-in
+
+The OAuth redirect is fixed to `http://localhost:4180/oauth2/callback`. When
+the browser and `dd-cli` run on different machines, forward that address from
+the browser machine to the Linux host. In a second terminal on the browser
+machine, keep this running (substitute the same destination used for SSH):
+
+```bash
+ssh -N -o ExitOnForwardFailure=yes \
+  -L 4180:127.0.0.1:4180 \
+  <user>@<linux-host>
+```
+
+On a headless Linux host, start a D-Bus shell first if the SSH session does not
+already have `DBUS_SESSION_BUS_ADDRESS`, then unlock GNOME Keyring without
+putting its password in shell history:
+
+```bash
+dbus-run-session -- bash  # only when DBUS_SESSION_BUS_ADDRESS is unset
+read -rsp "Keyring password: " dd_keyring_password; echo
+eval "$(printf '%s' "$dd_keyring_password" | \
+  gnome-keyring-daemon --unlock --components=secrets)"
+unset dd_keyring_password
+dd-cli login
+```
+
+Open the printed authorization URL on the browser machine. Its localhost
+callback travels through the SSH tunnel to the waiting CLI. Keep the D-Bus
+shell open for subsequent commands; an SSH session using public-key auth does
+not normally unlock the login keyring through PAM.
+
 ## Try it
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -6,6 +6,11 @@ DoorDash CLI (`dd-cli`) is a terminal tool for ordering from DoorDash — search
 
 Currently supported: **macOS, Apple Silicon (M1/M2/M3/M4)**.
 
+This repository also contains a community Linux rebuild workflow. It preserves
+the official release's packaged Python application bytecode and replaces its
+macOS-only runtime and keychain adapter with Linux equivalents. See
+[Linux rebuild](#linux-rebuild) below.
+
 ## Download
 
 1. Go to the [Releases page](https://github.com/doordash-oss/doordash-cli/releases) and open the latest release.
@@ -41,6 +46,30 @@ To compute the checksum of your download:
 ```bash
 shasum -a 256 dd-cli-v<version>-darwin-arm64.tar.gz
 ```
+
+## Linux rebuild
+
+On a 64-bit glibc Linux host (x86_64 or aarch64), run:
+
+```bash
+bash scripts/rebuild-linux.sh
+```
+
+The script selects the latest official macOS ARM64 release, verifies its
+published SHA256 digest, extracts the architecture-neutral Python package,
+recreates its exact dependency set on a matching Linux Python runtime, builds
+a native executable, exercises its command surface and Linux Secret Service
+credential path, and writes a binary plus installable archive under `dist/`.
+To rebuild a specific release, pass its version:
+
+```bash
+bash scripts/rebuild-linux.sh 0.2.1
+```
+
+The resulting CLI requires an unlocked Secret Service-compatible desktop
+keychain (for example GNOME Keyring). This matches the official CLI's rule that
+OAuth credentials must use an operating-system keychain; no plaintext token
+fallback is introduced.
 
 ## Try it
 

--- a/README.md
+++ b/README.md
@@ -67,17 +67,31 @@ specific release, pass its version:
 bash scripts/rebuild-linux.sh 0.2.1
 ```
 
-The resulting CLI requires an unlocked Secret Service-compatible desktop
-keychain (for example GNOME Keyring). This matches the official CLI's rule that
-OAuth credentials must use an operating-system keychain; no plaintext token
-fallback is introduced.
+The resulting CLI requires either an unlocked Secret Service-compatible
+desktop keychain (for example GNOME Keyring) or the optional authenticated
+1Password CLI backend below. Both keep OAuth credentials in encrypted
+credential storage; no plaintext token fallback is introduced.
 
-### Headless SSH sign-in
+### Headless sign-in
 
 The OAuth redirect is fixed to `http://localhost:4180/oauth2/callback`. When
-the browser and `dd-cli` run on different machines, forward that address from
-the browser machine to the Linux host. In a second terminal on the browser
-machine, keep this running (substitute the same destination used for SSH):
+the browser and `dd-cli` run on different machines, the simplest option is the
+Linux build's no-tunnel manual callback mode:
+
+```bash
+dd-cli login --manual
+```
+
+Open the printed authorization URL on any computer. After sign-in, the
+browser's final localhost page may report that it cannot connect. Copy the
+complete URL from its address bar and paste it at the hidden `Callback URL`
+prompt. The CLI validates its host, port, path, and OAuth state, then relays it
+only to its own loopback listener. The value is not added to shell history or
+echoed to the terminal.
+
+An SSH tunnel remains available if you prefer an automatic browser redirect.
+In a second terminal on the browser machine, keep this running (substitute the
+same destination used for SSH):
 
 ```bash
 ssh -N -o ExitOnForwardFailure=yes \
@@ -98,10 +112,11 @@ unset dd_keyring_password
 dd-cli login
 ```
 
-Open the printed authorization URL on the browser machine. Its localhost
-callback travels through the SSH tunnel to the waiting CLI. Keep the D-Bus
-shell open for subsequent commands; an SSH session using public-key auth does
-not normally unlock the login keyring through PAM.
+For tunnel mode, run `dd-cli login` without `--manual`, then open the printed
+authorization URL on the browser machine. Its localhost callback travels
+through the tunnel. Keep the D-Bus shell open for subsequent commands; an SSH
+session using public-key auth does not normally unlock the login keyring
+through PAM. Credential storage setup is required for either callback method.
 
 ### Optional 1Password credential storage
 
@@ -118,7 +133,7 @@ export DD_CLI_CREDENTIAL_BACKEND=1password
 export DD_CLI_1PASSWORD_VAULT='<vault name or ID>'
 # Optional when more than one account is configured:
 export DD_CLI_1PASSWORD_ACCOUNT='<account shorthand or ID>'
-dd-cli login
+dd-cli login --manual
 ```
 
 On first successful login, the backend creates a Password item titled
@@ -126,8 +141,9 @@ On first successful login, the backend creates a Password item titled
 `DD_CLI_1PASSWORD_ITEM` if needed. The OAuth document is sent to `op` over
 stdin and stored only in the concealed password field—never in command
 arguments, environment variables, or temporary files. The `op` session must
-remain authenticated when running subsequent `dd-cli` commands. The SSH port
-forward above is still required when the browser runs elsewhere.
+remain authenticated when running subsequent `dd-cli` commands. Manual
+callback mode does not require an SSH port forward; omit `--manual` and use the
+tunnel above if you prefer the automatic redirect.
 
 ## Try it
 

--- a/README.md
+++ b/README.md
@@ -103,6 +103,32 @@ callback travels through the SSH tunnel to the waiting CLI. Keep the D-Bus
 shell open for subsequent commands; an SSH session using public-key auth does
 not normally unlock the login keyring through PAM.
 
+### Optional 1Password credential storage
+
+For a headless host, the Linux build can replace Secret Service with the
+installed [1Password CLI](https://developer.1password.com/docs/cli/). This is
+opt-in; the default remains the operating-system keychain. Sign `op` in and
+choose a vault explicitly, then export the non-secret backend configuration
+for `login` and every later command:
+
+```bash
+op signin --account <account>
+op whoami
+export DD_CLI_CREDENTIAL_BACKEND=1password
+export DD_CLI_1PASSWORD_VAULT='<vault name or ID>'
+# Optional when more than one account is configured:
+export DD_CLI_1PASSWORD_ACCOUNT='<account shorthand or ID>'
+dd-cli login
+```
+
+On first successful login, the backend creates a Password item titled
+`dd-cli OAuth Tokens`; override that non-secret title with
+`DD_CLI_1PASSWORD_ITEM` if needed. The OAuth document is sent to `op` over
+stdin and stored only in the concealed password field—never in command
+arguments, environment variables, or temporary files. The `op` session must
+remain authenticated when running subsequent `dd-cli` commands. The SSH port
+forward above is still required when the browser runs elsewhere.
+
 ## Try it
 
 ```bash

--- a/linux/LINUX_PORT_NOTES.txt
+++ b/linux/LINUX_PORT_NOTES.txt
@@ -29,3 +29,10 @@ Secret Service remains the default credential backend. An opt-in 1Password
 backend implements the same Python Keyring interface by calling an installed
 `op` CLI. It is restricted to the `dd-cli` / `oauth-tokens` record and sends
 secrets only through stdin JSON. The 1Password CLI is not redistributed.
+
+The Linux runner also adds `login --manual` for remote browsers. DoorDash's
+registered localhost redirect URI is unchanged. The user pastes the browser's
+final callback URL into a hidden prompt; the adapter requires the expected
+loopback host, selected callback port and path, and matching OAuth state before
+replaying the unmodified query to the original local HTTP handler. This avoids
+an SSH tunnel without weakening PKCE or state validation.

--- a/linux/LINUX_PORT_NOTES.txt
+++ b/linux/LINUX_PORT_NOTES.txt
@@ -1,0 +1,21 @@
+LINUX REBUILD NOTES
+===================
+
+The official release contains a pure-Python `dd_cli` package inside a
+PyInstaller archive, plus a macOS ARM64 Python runtime. The Linux rebuild
+process copies the packaged Python bytecode without modifying it, builds it
+against a matching Linux Python runtime, recreates the exact dependency
+versions listed by the release, and adds the Secret Service support needed by
+Python Keyring on Linux.
+
+Linux-only runtime additions:
+
+- SecretStorage 3.5.0 (BSD-3-Clause)
+- jeepney 0.9.0 (MIT)
+- cryptography 50.0.0 (Apache-2.0 OR BSD-3-Clause)
+- cffi 2.1.0 (MIT)
+- pycparser 3.0 (BSD-3-Clause)
+
+The rebuilt binary still enforces the release's existing authentication gate,
+OAuth flow, TLS verification, MCP request construction, output sanitization,
+and ordering confirmations because those modules are unchanged.

--- a/linux/LINUX_PORT_NOTES.txt
+++ b/linux/LINUX_PORT_NOTES.txt
@@ -8,6 +8,11 @@ against a matching Linux Python runtime, recreates the exact dependency
 versions listed by the release, and adds the Secret Service support needed by
 Python Keyring on Linux.
 
+Native wheels are selected for the manylinux2014 (glibc 2.17) baseline. The
+build audits every bundled ELF shared object and rejects anything requiring a
+newer glibc. The target system supplies `libgcc_s.so.1`, as required by the
+manylinux platform contract, rather than receiving the build host's copy.
+
 Linux-only runtime additions:
 
 - SecretStorage 3.5.0 (BSD-3-Clause)

--- a/linux/LINUX_PORT_NOTES.txt
+++ b/linux/LINUX_PORT_NOTES.txt
@@ -24,3 +24,8 @@ Linux-only runtime additions:
 The rebuilt binary still enforces the release's existing authentication gate,
 OAuth flow, TLS verification, MCP request construction, output sanitization,
 and ordering confirmations because those modules are unchanged.
+
+Secret Service remains the default credential backend. An opt-in 1Password
+backend implements the same Python Keyring interface by calling an installed
+`op` CLI. It is restricted to the `dd-cli` / `oauth-tokens` record and sends
+secrets only through stdin JSON. The 1Password CLI is not redistributed.

--- a/linux/dd-cli.spec
+++ b/linux/dd-cli.spec
@@ -1,0 +1,48 @@
+# -*- mode: python ; coding: utf-8 -*-
+"""PyInstaller recipe for rebuilding the packaged dd_cli bytecode on Linux."""
+
+import os
+
+from PyInstaller.utils.hooks import collect_submodules
+
+
+app_path = os.environ["DD_CLI_APP_PATH"]
+metadata_path = os.environ["DD_CLI_METADATA_PATH"]
+metadata_dirname = os.path.basename(metadata_path)
+runner_path = os.environ["DD_CLI_RUNNER_PATH"]
+
+a = Analysis(
+    [runner_path],
+    pathex=[app_path],
+    binaries=[],
+    datas=[(metadata_path, metadata_dirname)],
+    hiddenimports=collect_submodules("keyring.backends"),
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=[],
+    noarchive=False,
+    optimize=0,
+)
+
+# Native manylinux wheels intentionally depend on the target system's libgcc.
+# PyInstaller otherwise copies the build host's libgcc, silently raising the
+# resulting binary's glibc floor to the build host's version.
+a.binaries = [entry for entry in a.binaries if entry[0] != "libgcc_s.so.1"]
+
+pyz = PYZ(a.pure)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    a.binaries,
+    a.datas,
+    [],
+    name="dd-cli",
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=False,
+    console=True,
+    disable_windowed_traceback=False,
+)

--- a/linux/headless_login.py
+++ b/linux/headless_login.py
@@ -1,0 +1,155 @@
+"""No-tunnel OAuth callback support for the Linux rebuild.
+
+DoorDash's OAuth client is registered with a loopback redirect URI.  A browser
+on another computer therefore redirects to that computer's localhost rather
+than the host running dd-cli.  Manual mode accepts the resulting callback URL
+through a hidden terminal prompt and replays it only to dd-cli's own loopback
+listener.
+"""
+
+from __future__ import annotations
+
+import functools
+import hmac
+import http.client
+import urllib.parse
+from collections.abc import Callable
+from typing import Any
+
+import click
+
+
+_CALLBACK_HOSTS = frozenset({"localhost", "127.0.0.1", "::1"})
+
+
+def _first_query_value(query: dict[str, list[str]], name: str) -> str | None:
+    values = query.get(name)
+    return values[0] if values else None
+
+
+def relay_callback_url(
+    authorization_url: str,
+    *,
+    prompt: Callable[..., str] = click.prompt,
+    connection_factory: Callable[..., Any] = http.client.HTTPConnection,
+) -> None:
+    """Read, validate, and relay one OAuth callback to the local listener."""
+
+    authorization = urllib.parse.urlsplit(authorization_url)
+    authorization_query = urllib.parse.parse_qs(authorization.query)
+    redirect_uri = _first_query_value(authorization_query, "redirect_uri")
+    expected_state = _first_query_value(authorization_query, "state")
+    if redirect_uri is None or expected_state is None:
+        raise click.ClickException("The authorization URL is missing OAuth callback metadata")
+
+    expected = urllib.parse.urlsplit(redirect_uri)
+    click.echo(
+        "Manual callback mode: finish signing in in the remote browser. "
+        "Its final localhost page may fail to load; copy the complete URL "
+        "from the address bar and paste it below.",
+        err=True,
+    )
+    pasted = prompt("Callback URL", hide_input=True, err=True).strip()
+
+    try:
+        callback = urllib.parse.urlsplit(pasted)
+        callback_port = callback.port
+        expected_port = expected.port
+    except ValueError as exc:
+        raise click.ClickException("The pasted callback URL has an invalid port") from exc
+
+    if (
+        callback.scheme != "http"
+        or callback.hostname not in _CALLBACK_HOSTS
+        or callback.username is not None
+        or callback.password is not None
+        or callback.fragment
+        or callback_port != expected_port
+        or callback.path != expected.path
+    ):
+        raise click.ClickException(
+            f"Expected the callback URL to start with {redirect_uri}?"
+        )
+
+    callback_query = urllib.parse.parse_qs(callback.query, keep_blank_values=True)
+    callback_state = _first_query_value(callback_query, "state")
+    if callback_state is None or not hmac.compare_digest(callback_state, expected_state):
+        raise click.ClickException("The pasted callback URL has an invalid OAuth state")
+    if not (_first_query_value(callback_query, "code") or callback_query.get("error")):
+        raise click.ClickException(
+            "The pasted callback URL contains neither an authorization code nor an OAuth error"
+        )
+
+    request_target = callback.path
+    if callback.query:
+        request_target = f"{request_target}?{callback.query}"
+    connection = None
+    try:
+        connection = connection_factory("127.0.0.1", expected_port, timeout=10)
+        connection.request(
+            "GET",
+            request_target,
+            headers={"Host": f"localhost:{expected_port}"},
+        )
+        response = connection.getresponse()
+        response.read()
+        if response.status != 200:
+            raise click.ClickException(
+                f"The local OAuth callback listener returned HTTP {response.status}"
+            )
+    except (OSError, http.client.HTTPException) as exc:
+        raise click.ClickException(
+            "Could not relay the callback to dd-cli's local OAuth listener"
+        ) from exc
+    finally:
+        if connection is not None:
+            connection.close()
+
+
+def configure_manual_login(
+    cli_group: click.Group,
+    oauth_module: Any,
+    *,
+    prompt: Callable[..., str] = click.prompt,
+    connection_factory: Callable[..., Any] = http.client.HTTPConnection,
+) -> None:
+    """Add ``--manual`` to the extracted release's existing login command."""
+
+    login_command = cli_group.commands.get("login")
+    if login_command is None or login_command.callback is None:
+        raise RuntimeError("The extracted dd-cli release has no login command")
+    if any(parameter.name == "manual" for parameter in login_command.params):
+        return
+
+    original_callback = login_command.callback
+
+    @functools.wraps(original_callback)
+    def callback(*, manual: bool = False, **parameters: Any) -> Any:
+        if not manual:
+            return original_callback(**parameters)
+
+        original_browser_open = oauth_module.webbrowser.open
+
+        def manual_browser_open(authorization_url: str, *_args: Any, **_kwargs: Any) -> bool:
+            relay_callback_url(
+                authorization_url,
+                prompt=prompt,
+                connection_factory=connection_factory,
+            )
+            return True
+
+        oauth_module.webbrowser.open = manual_browser_open
+        try:
+            return original_callback(**parameters)
+        finally:
+            oauth_module.webbrowser.open = original_browser_open
+
+    login_command.callback = callback
+    login_command.params.append(
+        click.Option(
+            ["--manual"],
+            is_flag=True,
+            default=False,
+            help="Paste the final localhost callback URL instead of using an SSH tunnel.",
+        )
+    )

--- a/linux/install.sh
+++ b/linux/install.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Install a rebuilt Linux dd-cli binary to ~/.local/bin/dd-cli.
+set -euo pipefail
+
+install_dir="${DD_CLI_INSTALL_DIR:-$HOME/.local/bin}"
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+
+mapfile -t candidates < <(find "$script_dir" -maxdepth 1 -type f \
+    \( -name 'dd-cli-v*-linux-x86_64' -o -name 'dd-cli-v*-linux-aarch64' \) \
+    -print)
+
+if [[ ${#candidates[@]} -ne 1 ]]; then
+    echo "Error: expected exactly one Linux dd-cli binary beside install.sh" >&2
+    exit 1
+fi
+
+case "$(uname -m)" in
+    x86_64) expected_suffix="linux-x86_64" ;;
+    aarch64|arm64) expected_suffix="linux-aarch64" ;;
+    *)
+        echo "Error: unsupported Linux architecture: $(uname -m)" >&2
+        exit 1
+        ;;
+esac
+
+binary="${candidates[0]}"
+if [[ "$binary" != *"-$expected_suffix" ]]; then
+    echo "Error: $(basename "$binary") does not match this machine ($expected_suffix)" >&2
+    exit 1
+fi
+
+mkdir -p "$install_dir"
+install -m 0755 "$binary" "$install_dir/dd-cli"
+
+echo "Installed dd-cli to $install_dir/dd-cli"
+if [[ ":$PATH:" != *":$install_dir:"* ]]; then
+    echo "Add $install_dir to PATH, then open a new shell."
+fi
+echo "Run: dd-cli --version"
+echo "Then: dd-cli login"

--- a/linux/onepassword_keyring.py
+++ b/linux/onepassword_keyring.py
@@ -1,0 +1,221 @@
+"""Optional Python Keyring backend backed by the 1Password CLI.
+
+The backend stores the complete OAuth token document in the concealed password
+field of a dedicated 1Password item. Secret values travel to ``op`` only over
+stdin and are never placed in command arguments, environment variables, or
+temporary files.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+from collections.abc import Callable, Mapping, Sequence
+from typing import Any
+
+import keyring
+from keyring.backend import KeyringBackend
+from keyring.errors import KeyringError, PasswordDeleteError
+
+
+_SERVICE = "dd-cli"
+_USERNAME = "oauth-tokens"
+_DEFAULT_ITEM = "dd-cli OAuth Tokens"
+
+
+class OnePasswordKeyring(KeyringBackend):
+    """Store the single dd-cli OAuth document in a 1Password item."""
+
+    priority = 10
+
+    def __init__(
+        self,
+        *,
+        vault: str,
+        item: str = _DEFAULT_ITEM,
+        account: str | None = None,
+        executable: str = "op",
+        process_runner: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run,
+    ) -> None:
+        if not vault.strip():
+            raise KeyringError("DD_CLI_1PASSWORD_VAULT must name a 1Password vault")
+        if not item.strip():
+            raise KeyringError("DD_CLI_1PASSWORD_ITEM cannot be empty")
+        self._vault = vault
+        self._item = item
+        self._account = account or None
+        self._executable = executable
+        self._process_runner = process_runner
+
+    def get_password(self, service: str, username: str) -> str | None:
+        if not self._in_scope(service, username):
+            return None
+        item_id = self._find_item_id()
+        if item_id is None:
+            return None
+        document = self._run_json(
+            "read credentials",
+            ["item", "get", item_id, "--vault", self._vault, "--format=json", "--reveal"],
+        )
+        value = self._password_field(document).get("value")
+        return value if isinstance(value, str) and value else None
+
+    def set_password(self, service: str, username: str, password: str) -> None:
+        self._require_scope(service, username)
+        item_id = self._find_item_id()
+        if item_id is None:
+            document = self._run_json(
+                "load the Password item template",
+                ["item", "template", "get", "Password"],
+            )
+            document["title"] = self._item
+            self._password_field(document)["value"] = password
+            self._run_json(
+                "create credentials",
+                ["item", "create", "--vault", self._vault, "--format=json", "-"],
+                document,
+            )
+            return
+
+        document = self._run_json(
+            "read credentials for update",
+            ["item", "get", item_id, "--vault", self._vault, "--format=json", "--reveal"],
+        )
+        self._password_field(document)["value"] = password
+        self._run_json(
+            "update credentials",
+            ["item", "edit", item_id, "--vault", self._vault, "--format=json"],
+            document,
+        )
+
+    def delete_password(self, service: str, username: str) -> None:
+        self._require_scope(service, username)
+        item_id = self._find_item_id()
+        if item_id is None:
+            raise PasswordDeleteError("No dd-cli OAuth credentials exist in 1Password")
+        document = self._run_json(
+            "read credentials for removal",
+            ["item", "get", item_id, "--vault", self._vault, "--format=json", "--reveal"],
+        )
+        self._password_field(document)["value"] = ""
+        self._run_json(
+            "remove credentials",
+            ["item", "edit", item_id, "--vault", self._vault, "--format=json"],
+            document,
+        )
+
+    def _find_item_id(self) -> str | None:
+        items = self._run_json(
+            "list credentials",
+            ["item", "list", "--vault", self._vault, "--format=json"],
+        )
+        if not isinstance(items, list):
+            raise KeyringError("1Password CLI returned an invalid item list")
+        matches = [
+            entry.get("id")
+            for entry in items
+            if isinstance(entry, dict) and entry.get("title") == self._item
+        ]
+        matches = [item_id for item_id in matches if isinstance(item_id, str) and item_id]
+        if len(matches) > 1:
+            raise KeyringError(
+                f"Multiple 1Password items are titled {self._item!r} in vault {self._vault!r}"
+            )
+        return matches[0] if matches else None
+
+    def _run_json(
+        self,
+        action: str,
+        arguments: Sequence[str],
+        input_document: Mapping[str, Any] | None = None,
+    ) -> Any:
+        command = [self._executable, *arguments]
+        if self._account:
+            command.extend(["--account", self._account])
+        input_text = json.dumps(input_document, separators=(",", ":")) if input_document else None
+        try:
+            result = self._process_runner(
+                command,
+                input=input_text,
+                text=True,
+                capture_output=True,
+                timeout=60,
+                check=False,
+            )
+        except (OSError, subprocess.SubprocessError) as exc:
+            raise KeyringError(
+                f"Could not {action} with 1Password CLI; run `op signin` and try again"
+            ) from exc
+        if result.returncode != 0:
+            raise KeyringError(
+                f"Could not {action} with 1Password CLI; run `op signin` and check vault access"
+            )
+        try:
+            return json.loads(result.stdout)
+        except (TypeError, json.JSONDecodeError) as exc:
+            raise KeyringError(
+                f"1Password CLI returned invalid JSON while trying to {action}"
+            ) from exc
+
+    @staticmethod
+    def _password_field(document: Any) -> dict[str, Any]:
+        if not isinstance(document, dict):
+            raise KeyringError("1Password CLI returned an invalid item document")
+        fields = document.get("fields")
+        if not isinstance(fields, list):
+            fields = []
+            document["fields"] = fields
+        for field in fields:
+            if isinstance(field, dict) and (
+                field.get("id") == "password" or field.get("purpose") == "PASSWORD"
+            ):
+                return field
+        field = {
+            "id": "password",
+            "type": "CONCEALED",
+            "purpose": "PASSWORD",
+            "label": "password",
+            "value": "",
+        }
+        fields.append(field)
+        return field
+
+    @staticmethod
+    def _in_scope(service: str, username: str) -> bool:
+        return service == _SERVICE and username == _USERNAME
+
+    @classmethod
+    def _require_scope(cls, service: str, username: str) -> None:
+        if not cls._in_scope(service, username):
+            raise KeyringError("The 1Password backend is restricted to dd-cli OAuth credentials")
+
+
+def configure_from_environment(environ: Mapping[str, str] | None = None) -> None:
+    """Select the opt-in 1Password backend before dd_cli imports keyring."""
+
+    values = os.environ if environ is None else environ
+    selection = values.get("DD_CLI_CREDENTIAL_BACKEND", "").strip().lower()
+    if not selection:
+        return
+    if selection not in {"1password", "onepassword", "op"}:
+        raise SystemExit(
+            "Error: DD_CLI_CREDENTIAL_BACKEND must be unset or one of: 1password, onepassword, op"
+        )
+    vault = values.get("DD_CLI_1PASSWORD_VAULT", "").strip()
+    if not vault:
+        raise SystemExit(
+            "Error: DD_CLI_1PASSWORD_VAULT is required when using the 1Password backend"
+        )
+    executable = shutil.which("op")
+    if executable is None:
+        raise SystemExit("Error: the 1Password CLI (`op`) is not installed or is not on PATH")
+    keyring.set_keyring(
+        OnePasswordKeyring(
+            vault=vault,
+            item=values.get("DD_CLI_1PASSWORD_ITEM", _DEFAULT_ITEM),
+            account=values.get("DD_CLI_1PASSWORD_ACCOUNT"),
+            executable=executable,
+        )
+    )

--- a/linux/onepassword_keyring.py
+++ b/linux/onepassword_keyring.py
@@ -12,6 +12,7 @@ import json
 import os
 import shutil
 import subprocess
+import sys
 from collections.abc import Callable, Mapping, Sequence
 from typing import Any
 
@@ -106,6 +107,18 @@ class OnePasswordKeyring(KeyringBackend):
             document,
         )
 
+    def verify_access(self) -> None:
+        """Fail before OAuth if the account session or vault is unavailable."""
+
+        self._run_json(
+            "verify the signed-in account",
+            ["whoami", "--format=json"],
+        )
+        self._run_json(
+            "access the configured vault",
+            ["vault", "get", self._vault, "--format=json"],
+        )
+
     def _find_item_id(self) -> str | None:
         items = self._run_json(
             "list credentials",
@@ -192,13 +205,15 @@ class OnePasswordKeyring(KeyringBackend):
             raise KeyringError("The 1Password backend is restricted to dd-cli OAuth credentials")
 
 
-def configure_from_environment(environ: Mapping[str, str] | None = None) -> None:
+def configure_from_environment(
+    environ: Mapping[str, str] | None = None,
+) -> OnePasswordKeyring | None:
     """Select the opt-in 1Password backend before dd_cli imports keyring."""
 
     values = os.environ if environ is None else environ
     selection = values.get("DD_CLI_CREDENTIAL_BACKEND", "").strip().lower()
     if not selection:
-        return
+        return None
     if selection not in {"1password", "onepassword", "op"}:
         raise SystemExit(
             "Error: DD_CLI_CREDENTIAL_BACKEND must be unset or one of: 1password, onepassword, op"
@@ -211,11 +226,34 @@ def configure_from_environment(environ: Mapping[str, str] | None = None) -> None
     executable = shutil.which("op")
     if executable is None:
         raise SystemExit("Error: the 1Password CLI (`op`) is not installed or is not on PATH")
-    keyring.set_keyring(
-        OnePasswordKeyring(
-            vault=vault,
-            item=values.get("DD_CLI_1PASSWORD_ITEM", _DEFAULT_ITEM),
-            account=values.get("DD_CLI_1PASSWORD_ACCOUNT"),
-            executable=executable,
-        )
+    backend = OnePasswordKeyring(
+        vault=vault,
+        item=values.get("DD_CLI_1PASSWORD_ITEM", _DEFAULT_ITEM),
+        account=values.get("DD_CLI_1PASSWORD_ACCOUNT"),
+        executable=executable,
     )
+    keyring.set_keyring(backend)
+    return backend
+
+
+def verify_access_for_invocation(
+    backend: OnePasswordKeyring | None,
+    arguments: Sequence[str] | None = None,
+    environ: Mapping[str, str] | None = None,
+) -> None:
+    """Check live 1Password access for commands that can consume credentials."""
+
+    if backend is None:
+        return
+    command_arguments = list(sys.argv[1:] if arguments is None else arguments)
+    values = os.environ if environ is None else environ
+    if (
+        not command_arguments
+        or any(argument in {"--help", "-h", "--version"} for argument in command_arguments)
+        or any(name.endswith("_COMPLETE") for name in values)
+    ):
+        return
+    try:
+        backend.verify_access()
+    except KeyringError as exc:
+        raise SystemExit(f"Error: {exc}") from None

--- a/linux/quickstart.txt
+++ b/linux/quickstart.txt
@@ -30,6 +30,31 @@ Secret Service provider. On Debian/Ubuntu, the usual packages are
 `gnome-keyring`, `dbus-user-session`, and `libsecret-1-0`; log out and back in
 after installing them so PAM can unlock the keyring.
 
+Headless SSH sign-in
+--------------------
+
+The OAuth redirect is fixed to localhost:4180. If your browser runs on a
+different machine, keep an SSH local-forward open from that browser machine:
+
+  ssh -N -o ExitOnForwardFailure=yes \
+    -L 4180:127.0.0.1:4180 \
+    <user>@<linux-host>
+
+On the Linux host, use a D-Bus shell if the SSH session does not already have
+DBUS_SESSION_BUS_ADDRESS. Then unlock GNOME Keyring without placing its
+password in shell history and start login:
+
+  dbus-run-session -- bash  # only when DBUS_SESSION_BUS_ADDRESS is unset
+  read -rsp "Keyring password: " dd_keyring_password; echo
+  eval "$(printf '%s' "$dd_keyring_password" | \
+    gnome-keyring-daemon --unlock --components=secrets)"
+  unset dd_keyring_password
+  dd-cli login
+
+Open the printed authorization URL on the browser machine while the SSH tunnel
+is running. Keep the D-Bus shell open for subsequent commands. SSH public-key
+authentication does not normally unlock the login keyring through PAM.
+
 Uninstall
 ---------
 

--- a/linux/quickstart.txt
+++ b/linux/quickstart.txt
@@ -1,0 +1,39 @@
+DoorDash CLI for Linux
+=======================
+
+This is a Linux rebuild of the official macOS ARM64 release. It keeps the
+release's architecture-neutral Python application bytecode and replaces the
+macOS interpreter, bootloader, TLS integration, and keychain backend with
+Linux equivalents.
+
+Requirements
+------------
+
+- 64-bit glibc Linux (x86_64 or aarch64, matching the archive name)
+- A desktop Secret Service keychain, such as GNOME Keyring, unlocked in the
+  current login session
+- An approved DoorDash CLI account
+
+Install
+-------
+
+  bash install.sh
+  export PATH="$HOME/.local/bin:$PATH"
+  dd-cli --version
+  dd-cli login
+
+The login command opens a browser and stores OAuth credentials in the Linux
+desktop keychain. There is deliberately no plaintext credential fallback.
+
+If dd-cli reports "Keychain unavailable", start or unlock your desktop's
+Secret Service provider. On Debian/Ubuntu, the usual packages are
+`gnome-keyring`, `dbus-user-session`, and `libsecret-1-0`; log out and back in
+after installing them so PAM can unlock the keyring.
+
+Uninstall
+---------
+
+  rm "$HOME/.local/bin/dd-cli"
+
+Removing the binary does not remove the `dd-cli` / `oauth-tokens` entry from
+your desktop keychain.

--- a/linux/quickstart.txt
+++ b/linux/quickstart.txt
@@ -9,7 +9,7 @@ Linux equivalents.
 Requirements
 ------------
 
-- 64-bit glibc Linux (x86_64 or aarch64, matching the archive name)
+- 64-bit glibc 2.17+ Linux (x86_64 or aarch64, matching the archive name)
 - A desktop Secret Service keychain, such as GNOME Keyring, unlocked in the
   current login session
 - An approved DoorDash CLI account

--- a/linux/quickstart.txt
+++ b/linux/quickstart.txt
@@ -55,6 +55,29 @@ Open the printed authorization URL on the browser machine while the SSH tunnel
 is running. Keep the D-Bus shell open for subsequent commands. SSH public-key
 authentication does not normally unlock the login keyring through PAM.
 
+Optional 1Password credential storage
+-------------------------------------
+
+The Linux build can use an installed 1Password CLI instead of Secret Service.
+This is opt-in; the operating-system keychain remains the default. Sign `op`
+in, select a vault explicitly, and export the same non-secret configuration
+for login and all later commands:
+
+  op signin --account <account>
+  op whoami
+  export DD_CLI_CREDENTIAL_BACKEND=1password
+  export DD_CLI_1PASSWORD_VAULT='<vault name or ID>'
+  # Optional for multiple configured accounts:
+  export DD_CLI_1PASSWORD_ACCOUNT='<account shorthand or ID>'
+  dd-cli login
+
+The backend creates a Password item titled `dd-cli OAuth Tokens` on first
+successful login. DD_CLI_1PASSWORD_ITEM can override that non-secret title.
+The OAuth document goes to `op` over stdin and is stored only in the concealed
+password field; it is never placed in command arguments, environment
+variables, or temporary files. Keep `op` authenticated for subsequent dd-cli
+commands. The SSH tunnel above is still required for a remote browser.
+
 Uninstall
 ---------
 

--- a/linux/quickstart.txt
+++ b/linux/quickstart.txt
@@ -10,8 +10,8 @@ Requirements
 ------------
 
 - 64-bit glibc 2.17+ Linux (x86_64 or aarch64, matching the archive name)
-- A desktop Secret Service keychain, such as GNOME Keyring, unlocked in the
-  current login session
+- Either a desktop Secret Service keychain, such as GNOME Keyring, unlocked in
+  the current login session, or an installed and authenticated 1Password CLI
 - An approved DoorDash CLI account
 
 Install
@@ -30,11 +30,20 @@ Secret Service provider. On Debian/Ubuntu, the usual packages are
 `gnome-keyring`, `dbus-user-session`, and `libsecret-1-0`; log out and back in
 after installing them so PAM can unlock the keyring.
 
-Headless SSH sign-in
---------------------
+Headless sign-in
+----------------
 
 The OAuth redirect is fixed to localhost:4180. If your browser runs on a
-different machine, keep an SSH local-forward open from that browser machine:
+different machine, use the no-tunnel manual callback mode:
+
+  dd-cli login --manual
+
+Open the printed authorization URL anywhere. The browser's final localhost
+page may fail to load; copy its complete address-bar URL and paste it at the
+hidden Callback URL prompt. It is validated and relayed only to the CLI's own
+loopback listener, without entering shell history.
+
+Alternatively, keep an SSH local-forward open from the browser machine:
 
   ssh -N -o ExitOnForwardFailure=yes \
     -L 4180:127.0.0.1:4180 \
@@ -51,9 +60,10 @@ password in shell history and start login:
   unset dd_keyring_password
   dd-cli login
 
-Open the printed authorization URL on the browser machine while the SSH tunnel
-is running. Keep the D-Bus shell open for subsequent commands. SSH public-key
-authentication does not normally unlock the login keyring through PAM.
+For tunnel mode, run `dd-cli login` without `--manual`, then open the printed
+URL while the tunnel is running. Keep the D-Bus shell open for subsequent
+commands. SSH public-key authentication does not normally unlock the login
+keyring through PAM.
 
 Optional 1Password credential storage
 -------------------------------------
@@ -69,14 +79,14 @@ for login and all later commands:
   export DD_CLI_1PASSWORD_VAULT='<vault name or ID>'
   # Optional for multiple configured accounts:
   export DD_CLI_1PASSWORD_ACCOUNT='<account shorthand or ID>'
-  dd-cli login
+  dd-cli login --manual
 
 The backend creates a Password item titled `dd-cli OAuth Tokens` on first
 successful login. DD_CLI_1PASSWORD_ITEM can override that non-secret title.
 The OAuth document goes to `op` over stdin and is stored only in the concealed
 password field; it is never placed in command arguments, environment
 variables, or temporary files. Keep `op` authenticated for subsequent dd-cli
-commands. The SSH tunnel above is still required for a remote browser.
+commands. Manual callback mode does not require an SSH tunnel.
 
 Uninstall
 ---------
@@ -84,4 +94,4 @@ Uninstall
   rm "$HOME/.local/bin/dd-cli"
 
 Removing the binary does not remove the `dd-cli` / `oauth-tokens` entry from
-your desktop keychain.
+your desktop keychain or the `dd-cli OAuth Tokens` item from 1Password.

--- a/linux/runner.py
+++ b/linux/runner.py
@@ -4,7 +4,11 @@ from onepassword_keyring import configure_from_environment
 
 configure_from_environment()
 
+from dd_cli import oauth
 from dd_cli.cli import cli
+from headless_login import configure_manual_login
+
+configure_manual_login(cli, oauth)
 
 
 if __name__ == "__main__":

--- a/linux/runner.py
+++ b/linux/runner.py
@@ -1,0 +1,7 @@
+"""Linux PyInstaller entry point for the extracted DoorDash CLI package."""
+
+from dd_cli.cli import cli
+
+
+if __name__ == "__main__":
+    cli()

--- a/linux/runner.py
+++ b/linux/runner.py
@@ -1,5 +1,9 @@
 """Linux PyInstaller entry point for the extracted DoorDash CLI package."""
 
+from onepassword_keyring import configure_from_environment
+
+configure_from_environment()
+
 from dd_cli.cli import cli
 
 

--- a/linux/runner.py
+++ b/linux/runner.py
@@ -1,8 +1,8 @@
 """Linux PyInstaller entry point for the extracted DoorDash CLI package."""
 
-from onepassword_keyring import configure_from_environment
+from onepassword_keyring import configure_from_environment, verify_access_for_invocation
 
-configure_from_environment()
+onepassword_backend = configure_from_environment()
 
 from dd_cli import oauth
 from dd_cli.cli import cli
@@ -12,4 +12,5 @@ configure_manual_login(cli, oauth)
 
 
 if __name__ == "__main__":
+    verify_access_for_invocation(onepassword_backend)
     cli()

--- a/scripts/rebuild-linux.sh
+++ b/scripts/rebuild-linux.sh
@@ -222,8 +222,11 @@ output_binary="$repo_root/dist/$artifact_stem"
 output_archive="$repo_root/dist/$artifact_stem.tar.gz"
 install -m 0755 "$built_binary" "$output_binary"
 tar --create --gzip --file "$output_archive" --directory "$work_dir/package" "$artifact_stem"
-sha256sum "$output_binary" >"$output_binary.sha256"
-sha256sum "$output_archive" >"$output_archive.sha256"
+(
+    cd "$repo_root/dist"
+    sha256sum "$artifact_stem" >"$artifact_stem.sha256"
+    sha256sum "$artifact_stem.tar.gz" >"$artifact_stem.tar.gz.sha256"
+)
 
 echo
 echo "Linux rebuild complete:"

--- a/scripts/rebuild-linux.sh
+++ b/scripts/rebuild-linux.sh
@@ -18,7 +18,7 @@ case "$(uname -m)" in
         ;;
 esac
 
-for command in curl file sha256sum tar python3; do
+for command in curl file objdump sha256sum tar python3; do
     command -v "$command" >/dev/null || {
         echo "Error: required command is missing: $command" >&2
         exit 1
@@ -165,9 +165,11 @@ export UV_CACHE_DIR="$work_dir/uv-cache"
 export UV_PYTHON_INSTALL_DIR="$work_dir/python"
 export UV_PYTHON_BIN_DIR="$work_dir/python-bin"
 uv_bin="$work_dir/bootstrap-venv/bin/uv"
+wheel_platform="${linux_arch}-manylinux_2_17"
 "$uv_bin" python install "$release_python"
 "$uv_bin" venv --managed-python --python "$release_python" "$work_dir/build-venv"
 "$uv_bin" pip install --python "$work_dir/build-venv/bin/python" \
+    --python-platform "$wheel_platform" \
     'pyinstaller==6.21.0' \
     'pyinstaller-hooks-contrib==2026.6' \
     "${release_requirements[@]}" \
@@ -177,20 +179,40 @@ uv_bin="$work_dir/bootstrap-venv/bin/uv"
     'cffi==2.1.0' \
     'pycparser==3.0'
 
+export DD_CLI_APP_PATH="$work_dir/app"
+export DD_CLI_METADATA_PATH="$metadata_source"
+export DD_CLI_RUNNER_PATH="$repo_root/linux/runner.py"
 "$work_dir/build-venv/bin/pyinstaller" \
     --noconfirm \
     --clean \
-    --onefile \
-    --name dd-cli \
-    --paths "$work_dir/app" \
-    --add-data "$metadata_source:dd_cli-$version.dist-info" \
-    --collect-submodules keyring.backends \
     --distpath "$work_dir/pyinstaller-dist" \
     --workpath "$work_dir/pyinstaller-build" \
-    --specpath "$work_dir" \
-    "$repo_root/linux/runner.py"
+    "$repo_root/linux/dd-cli.spec"
 
 built_binary="$work_dir/pyinstaller-dist/dd-cli"
+
+echo "Auditing bundled ELF compatibility..."
+mkdir -p "$work_dir/artifact-audit"
+(
+    cd "$work_dir/artifact-audit"
+    "$work_dir/bootstrap-venv/bin/pyinstxtractor-ng" "$built_binary" >/dev/null
+)
+audit_root="$work_dir/artifact-audit/dd-cli_extracted"
+if find "$audit_root" -type f -name 'libgcc_s.so*' -print -quit | grep -q .; then
+    echo "Error: the build bundled its host libgcc instead of using the target system's." >&2
+    exit 1
+fi
+while IFS= read -r elf_file; do
+    required_glibc="$(objdump -T "$elf_file" 2>/dev/null \
+        | grep -oE 'GLIBC_[0-9]+(\.[0-9]+)+' | sed 's/^GLIBC_//' | sort -Vu | tail -1 || true)"
+    [[ -z "$required_glibc" ]] && continue
+    highest="$(printf '%s\n' '2.17' "$required_glibc" | sort -V | tail -1)"
+    if [[ "$highest" != "2.17" ]]; then
+        echo "Error: $(basename "$elf_file") requires glibc $required_glibc (maximum: 2.17)." >&2
+        exit 1
+    fi
+done < <(find "$audit_root" -type f \( -name '*.so' -o -name '*.so.*' \) -print)
+
 KEYRING_PYTHON="$work_dir/build-venv/bin/python" \
     "$repo_root/scripts/smoke-test-linux.sh" "$built_binary" "$version"
 

--- a/scripts/rebuild-linux.sh
+++ b/scripts/rebuild-linux.sh
@@ -1,0 +1,232 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+requested_version="${1:-latest}"
+
+if [[ "$(uname -s)" != "Linux" ]]; then
+    echo "Error: this script builds a Linux executable and must run on Linux." >&2
+    exit 1
+fi
+
+case "$(uname -m)" in
+    x86_64) linux_arch="x86_64" ;;
+    aarch64|arm64) linux_arch="aarch64" ;;
+    *)
+        echo "Error: unsupported build architecture: $(uname -m)" >&2
+        exit 1
+        ;;
+esac
+
+for command in curl file sha256sum tar python3; do
+    command -v "$command" >/dev/null || {
+        echo "Error: required command is missing: $command" >&2
+        exit 1
+    }
+done
+
+mkdir -p "$repo_root/build" "$repo_root/dist"
+work_dir="$(mktemp -d "$repo_root/build/rebuild-linux.XXXXXX")"
+if [[ "${KEEP_BUILD:-0}" != "1" ]]; then
+    trap 'rm -rf "$work_dir"' EXIT
+else
+    echo "Keeping build workspace: $work_dir"
+fi
+
+release_json="$work_dir/releases.json"
+if command -v gh >/dev/null 2>&1 && gh auth status >/dev/null 2>&1; then
+    gh api 'repos/doordash-oss/doordash-cli/releases?per_page=100' >"$release_json"
+else
+    curl --fail --location --retry 3 \
+        --header 'Accept: application/vnd.github+json' \
+        --header 'User-Agent: doordash-cli-linux-rebuilder' \
+        'https://api.github.com/repos/doordash-oss/doordash-cli/releases?per_page=100' \
+        --output "$release_json"
+fi
+
+mapfile -t release_fields < <(python3 - "$release_json" "$requested_version" <<'PY'
+import json
+import re
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as handle:
+    releases = json.load(handle)
+
+requested = sys.argv[2].removeprefix("v")
+pattern = re.compile(r"^dd-cli-v(?P<version>[^-]+)-darwin-arm64\.tar\.gz$")
+selected = None
+for release in releases:
+    for asset in release.get("assets", []):
+        match = pattern.match(asset.get("name", ""))
+        if not match:
+            continue
+        if requested == "latest" or match.group("version") == requested:
+            selected = (release, asset, match.group("version"))
+            break
+    if selected:
+        break
+
+if selected is None:
+    raise SystemExit(f"No official darwin-arm64 release asset found for {sys.argv[2]!r}")
+
+release, asset, version = selected
+digest = asset.get("digest") or ""
+if digest.startswith("sha256:"):
+    digest = digest.removeprefix("sha256:")
+if not re.fullmatch(r"[0-9a-fA-F]{64}", digest):
+    body = release.get("body") or ""
+    found = re.search(r"SHA256:\s*([0-9a-fA-F]{64})", body, re.IGNORECASE)
+    if not found:
+        raise SystemExit("The release does not publish a usable SHA256 digest")
+    digest = found.group(1)
+
+print(version)
+print(asset["name"])
+print(asset["browser_download_url"])
+print(digest.lower())
+PY
+)
+
+if [[ ${#release_fields[@]} -ne 4 ]]; then
+    echo "Error: could not resolve the requested official release." >&2
+    exit 1
+fi
+
+version="${release_fields[0]}"
+source_asset="${release_fields[1]}"
+source_url="${release_fields[2]}"
+source_sha256="${release_fields[3]}"
+source_archive="$work_dir/$source_asset"
+
+echo "Downloading official dd-cli v$version release..."
+curl --fail --location --retry 3 "$source_url" --output "$source_archive"
+echo "$source_sha256  $source_archive" | sha256sum --check --status || {
+    echo "Error: official release checksum verification failed." >&2
+    exit 1
+}
+
+mkdir -p "$work_dir/source"
+tar -xzf "$source_archive" -C "$work_dir/source"
+source_binary="$(find "$work_dir/source" -type f -name "dd-cli-v$version-darwin-arm64" -print -quit)"
+[[ -n "$source_binary" ]] || { echo "Error: release binary not found after extraction." >&2; exit 1; }
+file "$source_binary" | grep -q 'Mach-O 64-bit arm64' || {
+    echo "Error: release input is not the expected macOS ARM64 executable." >&2
+    exit 1
+}
+
+echo "Extracting architecture-neutral Python package..."
+python3 -m venv "$work_dir/bootstrap-venv"
+"$work_dir/bootstrap-venv/bin/pip" --quiet --disable-pip-version-check install \
+    'uv==0.12.1' 'pyinstxtractor-ng==2026.7.3'
+archive_info="$("$work_dir/bootstrap-venv/bin/pyinstxtractor-ng" --info "$source_binary")"
+release_python="$(awk '/^\[\+\] Python version: / { print $4; exit }' <<<"$archive_info")"
+if [[ ! "$release_python" =~ ^3\.[0-9]+$ ]]; then
+    echo "Error: could not determine the release's Python version." >&2
+    exit 1
+fi
+mkdir -p "$work_dir/extracted"
+(
+    cd "$work_dir/extracted"
+    "$work_dir/bootstrap-venv/bin/pyinstxtractor-ng" "$source_binary"
+)
+
+extracted_root="$work_dir/extracted/$(basename "$source_binary")_extracted"
+app_source="$extracted_root/PYZ.pyz_extracted/dd_cli"
+metadata_source="$extracted_root/dd_cli-$version.dist-info"
+[[ -f "$app_source/cli.pyc" && -f "$metadata_source/METADATA" ]] || {
+    echo "Error: expected dd_cli package or metadata is absent from the release." >&2
+    exit 1
+}
+
+mkdir -p "$work_dir/app"
+cp -R "$app_source" "$work_dir/app/dd_cli"
+cp -R "$metadata_source" "$work_dir/app/dd_cli-$version.dist-info"
+
+release_root="$(dirname "$source_binary")"
+mapfile -t release_requirements < <(python3 - "$release_root/THIRD_PARTY_NOTICES.txt" <<'PY'
+import re
+import sys
+
+pattern = re.compile(r"^ (?P<name>[A-Za-z0-9_.-]+)  (?P<version>[^ ]+)$")
+with open(sys.argv[1], encoding="utf-8") as handle:
+    for line in handle:
+        match = pattern.match(line.rstrip("\n"))
+        if match:
+            print(f"{match.group('name')}=={match.group('version')}")
+PY
+)
+if [[ ${#release_requirements[@]} -eq 0 ]]; then
+    echo "Error: no dependency versions found in THIRD_PARTY_NOTICES.txt." >&2
+    exit 1
+fi
+
+echo "Building Linux Python $release_python executable..."
+export UV_CACHE_DIR="$work_dir/uv-cache"
+export UV_PYTHON_INSTALL_DIR="$work_dir/python"
+export UV_PYTHON_BIN_DIR="$work_dir/python-bin"
+uv_bin="$work_dir/bootstrap-venv/bin/uv"
+"$uv_bin" python install "$release_python"
+"$uv_bin" venv --managed-python --python "$release_python" "$work_dir/build-venv"
+"$uv_bin" pip install --python "$work_dir/build-venv/bin/python" \
+    'pyinstaller==6.21.0' \
+    'pyinstaller-hooks-contrib==2026.6' \
+    "${release_requirements[@]}" \
+    'secretstorage==3.5.0' \
+    'jeepney==0.9.0' \
+    'cryptography==50.0.0' \
+    'cffi==2.1.0' \
+    'pycparser==3.0'
+
+"$work_dir/build-venv/bin/pyinstaller" \
+    --noconfirm \
+    --clean \
+    --onefile \
+    --name dd-cli \
+    --paths "$work_dir/app" \
+    --add-data "$metadata_source:dd_cli-$version.dist-info" \
+    --collect-submodules keyring.backends \
+    --distpath "$work_dir/pyinstaller-dist" \
+    --workpath "$work_dir/pyinstaller-build" \
+    --specpath "$work_dir" \
+    "$repo_root/linux/runner.py"
+
+built_binary="$work_dir/pyinstaller-dist/dd-cli"
+KEYRING_PYTHON="$work_dir/build-venv/bin/python" \
+    "$repo_root/scripts/smoke-test-linux.sh" "$built_binary" "$version"
+
+artifact_stem="dd-cli-v$version-linux-$linux_arch"
+package_root="$work_dir/package/$artifact_stem"
+mkdir -p "$package_root/skills/dd-cli-usage"
+install -m 0755 "$built_binary" "$package_root/$artifact_stem"
+install -m 0755 "$repo_root/linux/install.sh" "$package_root/install.sh"
+install -m 0644 "$repo_root/linux/quickstart.txt" "$package_root/quickstart.txt"
+install -m 0644 "$repo_root/linux/LINUX_PORT_NOTES.txt" "$package_root/LINUX_PORT_NOTES.txt"
+
+install -m 0644 "$release_root/LICENSE.txt" "$package_root/LICENSE.txt"
+install -m 0644 "$release_root/THIRD_PARTY_NOTICES.txt" "$package_root/THIRD_PARTY_NOTICES.txt"
+if [[ -f "$release_root/skills/dd-cli-usage/SKILL.md" ]]; then
+    install -m 0644 "$release_root/skills/dd-cli-usage/SKILL.md" \
+        "$package_root/skills/dd-cli-usage/SKILL.md"
+fi
+
+cat >"$package_root/SOURCE_RELEASE.txt" <<EOF
+Official source release: dd-cli v$version
+Official asset: $source_asset
+Official asset SHA256: $source_sha256
+Official asset URL: $source_url
+Linux rebuild architecture: $linux_arch
+Linux Python runtime: $("$work_dir/build-venv/bin/python" --version 2>&1)
+EOF
+
+output_binary="$repo_root/dist/$artifact_stem"
+output_archive="$repo_root/dist/$artifact_stem.tar.gz"
+install -m 0755 "$built_binary" "$output_binary"
+tar --create --gzip --file "$output_archive" --directory "$work_dir/package" "$artifact_stem"
+sha256sum "$output_binary" >"$output_binary.sha256"
+sha256sum "$output_archive" >"$output_archive.sha256"
+
+echo
+echo "Linux rebuild complete:"
+echo "  $output_binary"
+echo "  $output_archive"
+echo "  $output_archive.sha256"

--- a/scripts/rebuild-linux.sh
+++ b/scripts/rebuild-linux.sh
@@ -179,9 +179,9 @@ wheel_platform="${linux_arch}-manylinux_2_17"
     'cffi==2.1.0' \
     'pycparser==3.0'
 
-echo "Testing the optional 1Password credential backend..."
+echo "Testing Linux credential and headless-login adapters..."
 PYTHONPATH="$repo_root/linux" "$work_dir/build-venv/bin/python" \
-    -m unittest discover -s "$repo_root/tests" -p 'test_onepassword_keyring.py'
+    -m unittest discover -s "$repo_root/tests" -p 'test_*.py'
 
 export DD_CLI_APP_PATH="$work_dir/app"
 export DD_CLI_METADATA_PATH="$metadata_source"

--- a/scripts/rebuild-linux.sh
+++ b/scripts/rebuild-linux.sh
@@ -179,6 +179,10 @@ wheel_platform="${linux_arch}-manylinux_2_17"
     'cffi==2.1.0' \
     'pycparser==3.0'
 
+echo "Testing the optional 1Password credential backend..."
+PYTHONPATH="$repo_root/linux" "$work_dir/build-venv/bin/python" \
+    -m unittest discover -s "$repo_root/tests" -p 'test_onepassword_keyring.py'
+
 export DD_CLI_APP_PATH="$work_dir/app"
 export DD_CLI_METADATA_PATH="$metadata_source"
 export DD_CLI_RUNNER_PATH="$repo_root/linux/runner.py"

--- a/scripts/smoke-test-linux.sh
+++ b/scripts/smoke-test-linux.sh
@@ -10,7 +10,7 @@ binary="$(realpath "$1")"
 expected_version="${2:-}"
 repo_root="$(cd "$(dirname "$0")/.." && pwd)"
 
-for command in curl file realpath seq timeout; do
+for command in curl file realpath sed seq timeout; do
     command -v "$command" >/dev/null || {
         echo "Required smoke-test command is missing: $command" >&2
         exit 1
@@ -82,6 +82,48 @@ set -e
 grep -Fq 'You can close this tab' "$callback_body"
 grep -Fq 'identity.doordash.com/authorize' "$oauth_stderr"
 grep -Fq 'Authentication/Authorization failed' "$oauth_stderr"
+
+# Exercise the no-tunnel path. It reads the browser's final localhost URL from
+# a hidden prompt and relays it to the same loopback callback server, so the
+# registered redirect URI and OAuth state validation remain unchanged.
+manual_dir="$(mktemp -d)"
+temporary_paths+=("$manual_dir")
+manual_input="$manual_dir/input"
+manual_stdout="$manual_dir/stdout"
+manual_stderr="$manual_dir/stderr"
+mkfifo "$manual_input"
+exec {manual_fd}<>"$manual_input"
+BROWSER=true timeout --signal=INT --kill-after=1 15 \
+    "$binary" login --manual <&$manual_fd >"$manual_stdout" 2>"$manual_stderr" &
+manual_pid=$!
+manual_auth_url=""
+for _attempt in $(seq 1 100); do
+    manual_auth_url="$(sed -n 's/^Open in browser: //p' "$manual_stderr" | tail -n 1)"
+    [[ -n "$manual_auth_url" ]] && break
+    sleep 0.1
+done
+manual_state="$(sed -n 's/.*[?&]state=\([^&]*\).*/\1/p' <<<"$manual_auth_url")"
+manual_port="$(sed -n 's/.*redirect_uri=http%3A%2F%2Flocalhost%3A\([0-9][0-9]*\)%2Foauth2%2Fcallback.*/\1/p' <<<"$manual_auth_url")"
+if [[ -z "$manual_state" || -z "$manual_port" ]]; then
+    kill "$manual_pid" 2>/dev/null || true
+    wait "$manual_pid" 2>/dev/null || true
+    echo "Manual OAuth flow did not print parseable callback metadata." >&2
+    exit 1
+fi
+printf '%s\n' \
+    "http://localhost:$manual_port/oauth2/callback?error=access_denied&error_description=manual-smoke&state=$manual_state" \
+    >&$manual_fd
+exec {manual_fd}>&-
+set +e
+wait "$manual_pid"
+manual_status=$?
+set -e
+[[ "$manual_status" -eq 1 ]] || {
+    echo "Manual OAuth denial returned unexpected status: $manual_status" >&2
+    exit 1
+}
+grep -Fq 'Manual callback mode' "$manual_stderr"
+grep -Fq 'Authentication/Authorization failed' "$manual_stderr"
 
 # Confirm the compiled runner can replace Secret Service with the optional
 # 1Password backend and pass the normal credential gate. The fixture exposes

--- a/scripts/smoke-test-linux.sh
+++ b/scripts/smoke-test-linux.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -lt 1 || $# -gt 2 ]]; then
+    echo "Usage: $0 <linux-binary> [expected-version]" >&2
+    exit 2
+fi
+
+binary="$(realpath "$1")"
+expected_version="${2:-}"
+
+[[ -x "$binary" ]] || { echo "Not executable: $binary" >&2; exit 1; }
+file "$binary" | grep -q 'ELF 64-bit'
+
+version_output="$($binary --version)"
+if [[ -n "$expected_version" ]]; then
+    grep -Fq "version $expected_version" <<<"$version_output"
+fi
+
+help_output="$($binary --help)"
+for command in login search menu store-details item-details \
+    restaurant-item-details find-items find-nearby-stores \
+    build-grocery-list cart promo order address payment-method; do
+    grep -Eq "^[[:space:]]+$command([[:space:]]|$)" <<<"$help_output" || {
+        echo "Missing root command in --help: $command" >&2
+        exit 1
+    }
+done
+
+# When a build-time Python containing keyring is supplied, exercise the actual
+# Linux Secret Service path as well as authenticated command-group loading.
+if [[ -n "${KEYRING_PYTHON:-}" ]] && command -v dbus-run-session >/dev/null \
+    && command -v gnome-keyring-daemon >/dev/null; then
+    smoke_home="$(mktemp -d)"
+    trap 'rm -rf "$smoke_home"' EXIT
+    export smoke_home binary
+    dbus-run-session -- bash -c '
+        set -euo pipefail
+        export HOME="$smoke_home"
+        eval "$(printf linux-smoke-keyring | gnome-keyring-daemon --unlock --components=secrets)"
+        "$KEYRING_PYTHON" -c '\''import keyring; keyring.set_password("dd-cli", "oauth-tokens", "{\"access_token\":\"smoke\",\"refresh_token\":\"smoke\",\"expires_at\":4102444800}")'\''
+        root_commands=(login search menu store-details item-details
+            restaurant-item-details find-items find-nearby-stores
+            build-grocery-list cart promo order address payment-method)
+        for command in "${root_commands[@]}"; do
+            "$binary" "$command" --help >/dev/null
+        done
+
+        nested_commands=(
+            "cart list" "cart add-items" "cart show" "cart remove-item" "cart delete"
+            "promo list" "promo apply" "promo remove"
+            "order history" "order reorder" "order receipt" "order status"
+            "order preview" "order submit" "order checkout-url"
+            "address list" "address set" "payment-method list"
+        )
+        for command in "${nested_commands[@]}"; do
+            read -r -a args <<<"$command"
+            "$binary" "${args[@]}" --help >/dev/null
+        done
+    '
+fi
+
+echo "Linux smoke tests passed: $version_output"

--- a/scripts/smoke-test-linux.sh
+++ b/scripts/smoke-test-linux.sh
@@ -10,7 +10,7 @@ binary="$(realpath "$1")"
 expected_version="${2:-}"
 repo_root="$(cd "$(dirname "$0")/.." && pwd)"
 
-for command in curl file realpath sed seq timeout; do
+for command in curl env file realpath sed seq setsid timeout; do
     command -v "$command" >/dev/null || {
         echo "Required smoke-test command is missing: $command" >&2
         exit 1
@@ -53,7 +53,11 @@ oauth_stdout="$(mktemp)"
 oauth_stderr="$(mktemp)"
 callback_body="$(mktemp)"
 temporary_paths+=("$oauth_stdout" "$oauth_stderr" "$callback_body")
-BROWSER=true timeout --signal=INT --kill-after=1 15 \
+env -u DD_CLI_CREDENTIAL_BACKEND \
+    -u DD_CLI_1PASSWORD_VAULT \
+    -u DD_CLI_1PASSWORD_ACCOUNT \
+    -u DD_CLI_1PASSWORD_ITEM \
+    BROWSER=true timeout --signal=INT --kill-after=1 15 \
     "$binary" login >"$oauth_stdout" 2>"$oauth_stderr" &
 oauth_pid=$!
 callback_received=0
@@ -93,8 +97,14 @@ manual_stdout="$manual_dir/stdout"
 manual_stderr="$manual_dir/stderr"
 mkfifo "$manual_input"
 exec {manual_fd}<>"$manual_input"
-BROWSER=true timeout --signal=INT --kill-after=1 15 \
-    "$binary" login --manual <&$manual_fd >"$manual_stdout" 2>"$manual_stderr" &
+# Detach the controlling TTY so getpass reads the synthetic URL from the FIFO.
+env -u DD_CLI_CREDENTIAL_BACKEND \
+    -u DD_CLI_1PASSWORD_VAULT \
+    -u DD_CLI_1PASSWORD_ACCOUNT \
+    -u DD_CLI_1PASSWORD_ITEM \
+    BROWSER=true timeout --signal=INT --kill-after=1 15 \
+    setsid --wait "$binary" login --manual \
+    <&$manual_fd >"$manual_stdout" 2>"$manual_stderr" &
 manual_pid=$!
 manual_auth_url=""
 for _attempt in $(seq 1 100); do
@@ -133,7 +143,9 @@ if [[ -x "$repo_root/tests/fake-op" ]]; then
     fake_op_dir="$(mktemp -d)"
     temporary_paths+=("$fake_op_dir")
     ln -s "$repo_root/tests/fake-op" "$fake_op_dir/op"
-    PATH="$fake_op_dir:$PATH" \
+    env -u DD_CLI_1PASSWORD_ACCOUNT \
+        -u DD_CLI_1PASSWORD_ITEM \
+        PATH="$fake_op_dir:$PATH" \
         DD_CLI_CREDENTIAL_BACKEND=1password \
         DD_CLI_1PASSWORD_VAULT='Smoke Test' \
         "$binary" order --help | grep -Fq 'checkout-url'
@@ -148,6 +160,8 @@ if [[ -n "${KEYRING_PYTHON:-}" ]] && command -v dbus-run-session >/dev/null \
     export smoke_home binary
     dbus-run-session -- bash -c '
         set -euo pipefail
+        unset DD_CLI_CREDENTIAL_BACKEND DD_CLI_1PASSWORD_VAULT \
+            DD_CLI_1PASSWORD_ACCOUNT DD_CLI_1PASSWORD_ITEM
         export HOME="$smoke_home"
         eval "$(printf linux-smoke-keyring | gnome-keyring-daemon --unlock --components=secrets)"
         "$KEYRING_PYTHON" -c '\''import keyring; keyring.set_password("dd-cli", "oauth-tokens", "{\"access_token\":\"smoke\",\"refresh_token\":\"smoke\",\"expires_at\":4102444800}")'\''

--- a/scripts/smoke-test-linux.sh
+++ b/scripts/smoke-test-linux.sh
@@ -9,6 +9,25 @@ fi
 binary="$(realpath "$1")"
 expected_version="${2:-}"
 
+for command in curl file realpath seq timeout; do
+    command -v "$command" >/dev/null || {
+        echo "Required smoke-test command is missing: $command" >&2
+        exit 1
+    }
+done
+
+temporary_paths=()
+cleanup() {
+    for temporary_path in "${temporary_paths[@]}"; do
+        if [[ -d "$temporary_path" ]]; then
+            rm -rf -- "$temporary_path"
+        else
+            rm -f -- "$temporary_path"
+        fi
+    done
+}
+trap cleanup EXIT
+
 [[ -x "$binary" ]] || { echo "Not executable: $binary" >&2; exit 1; }
 file "$binary" | grep -q 'ELF 64-bit'
 
@@ -27,12 +46,48 @@ for command in login search menu store-details item-details \
     }
 done
 
+# Exercise browser launch and the localhost OAuth callback server without
+# exchanging a real authorization code or persisting credentials.
+oauth_stdout="$(mktemp)"
+oauth_stderr="$(mktemp)"
+callback_body="$(mktemp)"
+temporary_paths+=("$oauth_stdout" "$oauth_stderr" "$callback_body")
+BROWSER=true timeout --signal=INT --kill-after=1 15 \
+    "$binary" login >"$oauth_stdout" 2>"$oauth_stderr" &
+oauth_pid=$!
+callback_received=0
+for _attempt in $(seq 1 100); do
+    if curl --silent --fail --output "$callback_body" \
+        'http://localhost:4180/oauth2/callback?error=access_denied&error_description=linux-smoke'; then
+        callback_received=1
+        break
+    fi
+    sleep 0.1
+done
+if [[ "$callback_received" -ne 1 ]]; then
+    kill "$oauth_pid" 2>/dev/null || true
+    wait "$oauth_pid" 2>/dev/null || true
+    echo "OAuth callback listener did not become ready." >&2
+    exit 1
+fi
+set +e
+wait "$oauth_pid"
+oauth_status=$?
+set -e
+[[ "$oauth_status" -eq 1 ]] || {
+    echo "OAuth denial returned unexpected status: $oauth_status" >&2
+    exit 1
+}
+grep -Fq 'You can close this tab' "$callback_body"
+grep -Fq 'identity.doordash.com/authorize' "$oauth_stderr"
+grep -Fq 'Authentication/Authorization failed' "$oauth_stderr"
+
 # When a build-time Python containing keyring is supplied, exercise the actual
 # Linux Secret Service path as well as authenticated command-group loading.
 if [[ -n "${KEYRING_PYTHON:-}" ]] && command -v dbus-run-session >/dev/null \
     && command -v gnome-keyring-daemon >/dev/null; then
     smoke_home="$(mktemp -d)"
-    trap 'rm -rf "$smoke_home"' EXIT
+    temporary_paths+=("$smoke_home")
     export smoke_home binary
     dbus-run-session -- bash -c '
         set -euo pipefail

--- a/scripts/smoke-test-linux.sh
+++ b/scripts/smoke-test-linux.sh
@@ -8,6 +8,7 @@ fi
 
 binary="$(realpath "$1")"
 expected_version="${2:-}"
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
 
 for command in curl file realpath seq timeout; do
     command -v "$command" >/dev/null || {
@@ -81,6 +82,20 @@ set -e
 grep -Fq 'You can close this tab' "$callback_body"
 grep -Fq 'identity.doordash.com/authorize' "$oauth_stderr"
 grep -Fq 'Authentication/Authorization failed' "$oauth_stderr"
+
+# Confirm the compiled runner can replace Secret Service with the optional
+# 1Password backend and pass the normal credential gate. The fixture exposes
+# only a synthetic token and implements read operations; backend writes are
+# covered by the Python unit tests.
+if [[ -x "$repo_root/tests/fake-op" ]]; then
+    fake_op_dir="$(mktemp -d)"
+    temporary_paths+=("$fake_op_dir")
+    ln -s "$repo_root/tests/fake-op" "$fake_op_dir/op"
+    PATH="$fake_op_dir:$PATH" \
+        DD_CLI_CREDENTIAL_BACKEND=1password \
+        DD_CLI_1PASSWORD_VAULT='Smoke Test' \
+        "$binary" order --help | grep -Fq 'checkout-url'
+fi
 
 # When a build-time Python containing keyring is supplied, exercise the actual
 # Linux Secret Service path as well as authenticated command-group loading.

--- a/tests/fake-op
+++ b/tests/fake-op
@@ -3,6 +3,12 @@
 set -euo pipefail
 
 case "${1:-} ${2:-}" in
+    "whoami --format=json")
+        printf '%s\n' '{"account_uuid":"fake-account"}'
+        ;;
+    "vault get")
+        printf '%s\n' '{"id":"fake-vault","name":"Smoke Test"}'
+        ;;
     "item list")
         printf '%s\n' '[{"id":"fake-dd-cli-item","title":"dd-cli OAuth Tokens"}]'
         ;;

--- a/tests/fake-op
+++ b/tests/fake-op
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Minimal read-only 1Password CLI fixture for the compiled-binary smoke test.
+set -euo pipefail
+
+case "${1:-} ${2:-}" in
+    "item list")
+        printf '%s\n' '[{"id":"fake-dd-cli-item","title":"dd-cli OAuth Tokens"}]'
+        ;;
+    "item get")
+        printf '%s\n' '{"id":"fake-dd-cli-item","title":"dd-cli OAuth Tokens","fields":[{"id":"password","type":"CONCEALED","purpose":"PASSWORD","label":"password","value":"{\"access_token\":\"smoke\",\"refresh_token\":\"smoke\",\"expires_at\":4102444800}"}]}'
+        ;;
+    *)
+        echo "Unsupported fake op command" >&2
+        exit 2
+        ;;
+esac

--- a/tests/test_headless_login.py
+++ b/tests/test_headless_login.py
@@ -1,0 +1,154 @@
+"""Tests for the no-tunnel OAuth callback relay."""
+
+from __future__ import annotations
+
+import types
+import unittest
+import urllib.parse
+
+import click
+from click.testing import CliRunner
+
+from headless_login import configure_manual_login, relay_callback_url
+
+
+class FakeResponse:
+    status = 200
+
+    def read(self) -> bytes:
+        return b"ok"
+
+
+class FakeConnection:
+    instances: list["FakeConnection"] = []
+
+    def __init__(self, host: str, port: int, *, timeout: int) -> None:
+        self.host = host
+        self.port = port
+        self.timeout = timeout
+        self.request_data: tuple | None = None
+        self.closed = False
+        self.instances.append(self)
+
+    def request(self, method: str, target: str, *, headers: dict[str, str]) -> None:
+        self.request_data = (method, target, headers)
+
+    def getresponse(self) -> FakeResponse:
+        return FakeResponse()
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def authorization_url(state: str = "expected-state") -> str:
+    query = urllib.parse.urlencode(
+        {
+            "redirect_uri": "http://localhost:4180/oauth2/callback",
+            "state": state,
+        }
+    )
+    return f"https://identity.doordash.com/authorize?{query}"
+
+
+class HeadlessLoginTests(unittest.TestCase):
+    def setUp(self) -> None:
+        FakeConnection.instances.clear()
+
+    def test_relay_validates_and_forwards_callback_without_exposing_code(self) -> None:
+        callback = (
+            "http://localhost:4180/oauth2/callback?"
+            "code=very-secret&state=expected-state"
+        )
+        relay_callback_url(
+            authorization_url(),
+            prompt=lambda *_args, **_kwargs: callback,
+            connection_factory=FakeConnection,
+        )
+
+        connection = FakeConnection.instances[0]
+        self.assertEqual((connection.host, connection.port), ("127.0.0.1", 4180))
+        self.assertEqual(connection.request_data[0], "GET")
+        self.assertIn("code=very-secret", connection.request_data[1])
+        self.assertTrue(connection.closed)
+
+    def test_relay_rejects_non_loopback_destination(self) -> None:
+        callback = (
+            "http://attacker.example:4180/oauth2/callback?"
+            "code=very-secret&state=expected-state"
+        )
+        with self.assertRaises(click.ClickException):
+            relay_callback_url(
+                authorization_url(),
+                prompt=lambda *_args, **_kwargs: callback,
+                connection_factory=FakeConnection,
+            )
+        self.assertEqual(FakeConnection.instances, [])
+
+    def test_relay_rejects_state_mismatch(self) -> None:
+        callback = (
+            "http://localhost:4180/oauth2/callback?"
+            "code=very-secret&state=wrong-state"
+        )
+        with self.assertRaises(click.ClickException):
+            relay_callback_url(
+                authorization_url(),
+                prompt=lambda *_args, **_kwargs: callback,
+                connection_factory=FakeConnection,
+            )
+        self.assertEqual(FakeConnection.instances, [])
+
+    def test_relay_reports_local_connection_failure_cleanly(self) -> None:
+        callback = (
+            "http://localhost:4180/oauth2/callback?"
+            "code=very-secret&state=expected-state"
+        )
+
+        def failing_connection(*_args, **_kwargs):
+            raise ConnectionRefusedError
+
+        with self.assertRaisesRegex(
+            click.ClickException, "Could not relay the callback"
+        ):
+            relay_callback_url(
+                authorization_url(),
+                prompt=lambda *_args, **_kwargs: callback,
+                connection_factory=failing_connection,
+            )
+
+    def test_manual_option_wraps_and_restores_browser_open(self) -> None:
+        opened: list[str] = []
+
+        def original_open(url: str) -> bool:
+            opened.append(url)
+            return True
+
+        oauth = types.SimpleNamespace(webbrowser=types.SimpleNamespace(open=original_open))
+        group = click.Group()
+
+        @click.command("login")
+        @click.option("--verbose", is_flag=True)
+        def login(verbose: bool) -> None:
+            del verbose
+            oauth.webbrowser.open(authorization_url())
+
+        group.add_command(login)
+        callback = (
+            "http://localhost:4180/oauth2/callback?"
+            "error=access_denied&state=expected-state"
+        )
+        configure_manual_login(
+            group,
+            oauth,
+            prompt=lambda *_args, **_kwargs: callback,
+            connection_factory=FakeConnection,
+        )
+
+        result = CliRunner().invoke(group, ["login", "--manual"])
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertEqual(opened, [])
+        self.assertIs(oauth.webbrowser.open, original_open)
+        self.assertEqual(len(FakeConnection.instances), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_onepassword_keyring.py
+++ b/tests/test_onepassword_keyring.py
@@ -8,7 +8,7 @@ import unittest
 
 from keyring.errors import KeyringError, PasswordDeleteError
 
-from onepassword_keyring import OnePasswordKeyring
+from onepassword_keyring import OnePasswordKeyring, verify_access_for_invocation
 
 
 class FakeOp:
@@ -20,6 +20,10 @@ class FakeOp:
         input_text = kwargs.get("input")
         self.calls.append((command, input_text))
         operation = command[1:3]
+        if command[1] == "whoami":
+            return self._result({"account_uuid": "test-account"})
+        if operation == ["vault", "get"]:
+            return self._result({"id": "test-vault", "name": "Test Vault"})
         if operation == ["item", "list"]:
             items = (
                 []
@@ -106,6 +110,37 @@ class OnePasswordKeyringTests(unittest.TestCase):
         with self.assertRaises(KeyringError) as raised:
             backend.set_password("dd-cli", "oauth-tokens", secret)
         self.assertNotIn(secret, str(raised.exception))
+
+    def test_verify_access_checks_account_and_vault(self) -> None:
+        self.backend.verify_access()
+        self.assertTrue(any(command[1] == "whoami" for command, _ in self.fake.calls))
+        self.assertTrue(
+            any(command[1:3] == ["vault", "get"] for command, _ in self.fake.calls)
+        )
+
+    def test_invocation_preflight_reports_signin_failure(self) -> None:
+        def failing_runner(command, **kwargs):
+            return subprocess.CompletedProcess(command, 1, "", "signed out")
+
+        backend = OnePasswordKeyring(
+            vault="Test Vault",
+            executable="/test/bin/op",
+            process_runner=failing_runner,
+        )
+        with self.assertRaisesRegex(SystemExit, "verify the signed-in account"):
+            verify_access_for_invocation(backend, ["login"], {})
+
+    def test_invocation_preflight_skips_help_and_completion(self) -> None:
+        def unexpected_runner(*_args, **_kwargs):
+            raise AssertionError("metadata commands must not access 1Password")
+
+        backend = OnePasswordKeyring(
+            vault="Test Vault",
+            executable="/test/bin/op",
+            process_runner=unexpected_runner,
+        )
+        verify_access_for_invocation(backend, ["login", "--help"], {})
+        verify_access_for_invocation(backend, ["login"], {"_DD_CLI_COMPLETE": "bash_source"})
 
 
 if __name__ == "__main__":

--- a/tests/test_onepassword_keyring.py
+++ b/tests/test_onepassword_keyring.py
@@ -1,0 +1,112 @@
+"""Tests for the optional 1Password Python Keyring backend."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import unittest
+
+from keyring.errors import KeyringError, PasswordDeleteError
+
+from onepassword_keyring import OnePasswordKeyring
+
+
+class FakeOp:
+    def __init__(self) -> None:
+        self.document: dict | None = None
+        self.calls: list[tuple[list[str], str | None]] = []
+
+    def __call__(self, command: list[str], **kwargs) -> subprocess.CompletedProcess[str]:
+        input_text = kwargs.get("input")
+        self.calls.append((command, input_text))
+        operation = command[1:3]
+        if operation == ["item", "list"]:
+            items = (
+                []
+                if self.document is None
+                else [{"id": "item-id", "title": self.document["title"]}]
+            )
+            return self._result(items)
+        if operation == ["item", "template"]:
+            return self._result(
+                {
+                    "title": "",
+                    "category": "PASSWORD",
+                    "fields": [
+                        {
+                            "id": "password",
+                            "type": "CONCEALED",
+                            "purpose": "PASSWORD",
+                            "label": "password",
+                            "value": "",
+                        }
+                    ],
+                }
+            )
+        if operation == ["item", "get"]:
+            return self._result(self.document)
+        if operation in (["item", "create"], ["item", "edit"]):
+            self.document = json.loads(input_text)
+            return self._result(self.document)
+        return subprocess.CompletedProcess(command, 1, "", "unexpected fake command")
+
+    @staticmethod
+    def _result(value) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(["op"], 0, json.dumps(value), "")
+
+
+class OnePasswordKeyringTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.fake = FakeOp()
+        self.backend = OnePasswordKeyring(
+            vault="Test Vault",
+            executable="/test/bin/op",
+            process_runner=self.fake,
+        )
+
+    def test_create_and_read_keep_secret_out_of_arguments(self) -> None:
+        secret = '{"access_token":"top-secret","refresh_token":"also-secret"}'
+        self.backend.set_password("dd-cli", "oauth-tokens", secret)
+        self.assertEqual(self.backend.get_password("dd-cli", "oauth-tokens"), secret)
+        self.assertTrue(
+            any("top-secret" in (input_text or "") for _, input_text in self.fake.calls)
+        )
+        self.assertFalse(
+            any(secret in argument for command, _ in self.fake.calls for argument in command)
+        )
+
+    def test_update_and_delete_keep_dedicated_item(self) -> None:
+        self.backend.set_password("dd-cli", "oauth-tokens", "first")
+        self.backend.set_password("dd-cli", "oauth-tokens", "second")
+        self.assertEqual(self.backend.get_password("dd-cli", "oauth-tokens"), "second")
+        self.backend.delete_password("dd-cli", "oauth-tokens")
+        self.assertIsNone(self.backend.get_password("dd-cli", "oauth-tokens"))
+        self.assertIsNotNone(self.fake.document)
+
+    def test_delete_missing_credentials_raises_keyring_error(self) -> None:
+        with self.assertRaises(PasswordDeleteError):
+            self.backend.delete_password("dd-cli", "oauth-tokens")
+
+    def test_backend_is_restricted_to_dd_cli_token_document(self) -> None:
+        self.assertIsNone(self.backend.get_password("another-service", "oauth-tokens"))
+        with self.assertRaises(KeyringError):
+            self.backend.set_password("another-service", "oauth-tokens", "secret")
+
+    def test_cli_error_does_not_echo_sensitive_input(self) -> None:
+        secret = "never-echo-this"
+
+        def failing_runner(command, **kwargs):
+            return subprocess.CompletedProcess(command, 1, "", f"failed with {secret}")
+
+        backend = OnePasswordKeyring(
+            vault="Test Vault",
+            executable="/test/bin/op",
+            process_runner=failing_runner,
+        )
+        with self.assertRaises(KeyringError) as raised:
+            backend.set_password("dd-cli", "oauth-tokens", secret)
+        self.assertNotIn(secret, str(raised.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add a checksum-verifying workflow that downloads an official macOS ARM64 release and extracts its architecture-neutral Python package
- rebuild the unchanged application bytecode with a matching Linux Python runtime and exact release dependencies
- select native wheels for the manylinux2014 / glibc 2.17 baseline and reject bundled ELF objects requiring anything newer
- add Linux Secret Service support, installer/quickstart packaging, provenance, and portable SHA256 outputs
- add `login --manual`, which securely relays a pasted remote-browser callback to the original loopback handler without an SSH tunnel
- preserve SSH port-forwarding as an optional automatic callback method
- add an opt-in 1Password CLI credential backend while retaining Secret Service as the default
- pass OAuth token JSON to 1Password through stdin only, never command arguments, environment variables, or temporary files
- preflight the selected 1Password account and vault before OAuth so storage failures are actionable and cannot discard a completed login
- add smoke coverage for the ELF artifact, both OAuth callback modes, full Click command tree, Secret Service, and the compiled 1Password read path

## Verification

- `bash scripts/rebuild-linux.sh 0.2.1`
- ran all 13 Linux adapter unit tests
- verified the official input SHA256 before extraction
- verified generated binary and archive SHA256 files
- audited every bundled shared object: maximum GLIBC requirement is 2.17 and host `libgcc_s` is not bundled
- ran the binary in clean Ubuntu 20.04, Debian 11, and Fedora 40 containers
- ran the complete keyring-backed smoke suite inside an Ubuntu 20.04 container
- exercised browser launch plus the localhost OAuth callback denial path without exchanging a real authorization code
- exercised the compiled no-tunnel path by parsing its emitted state/port and relaying a synthetic callback through the original HTTP handler
- reran the complete rebuild from an interactive TTY; the manual callback fixture runs under `setsid --wait`, consumes its FIFO deterministically, and no longer times out with status 137
- confirmed a signed-out compiled 1Password invocation fails early with an explicit account-session error while help/version remain available
- sent a read-only compiled request with a synthetic token to DoorDash and received the expected authentication rejection, proving live Linux DNS, CA/TLS, HTTP, credential loading, request construction, and error mapping
- statically audited the extracted release's platform branch: Linux selects Python Keyring; `/usr/bin/security` is reachable only when `sys.platform == "darwin"`
- loaded all 15 root commands and all 18 nested commands with `--help` through a temporary Secret Service session
- exercised the compiled optional 1Password path with a synthetic read-only `op` fixture
- verified the real backend against an authenticated 1Password vault: create, read, update, clear, and recoverable cleanup of a uniquely named synthetic item
- completed a real DoorDash browser OAuth grant through the installed Linux binary and confirmed the token persisted in 1Password across processes
- completed authenticated read-only address, order-history, active-cart, payment-method, and restaurant-discovery calls; every response exited 0 with `success=true` and `isError=false`
- extracted the generated archive, ran `install.sh` into an isolated prefix, and executed the installed `dd-cli --version`

## Notes

Generated build workspaces and release artifacts remain ignored. Secret Service remains the zero-configuration default. The optional 1Password backend requires an installed and authenticated `op` CLI plus `DD_CLI_CREDENTIAL_BACKEND=1password` and `DD_CLI_1PASSWORD_VAULT`. Live account verification completed with an approved user: a successful DoorDash OAuth grant, persistent 1Password token storage, and five independent authenticated read-only command families. No cart/address/payment mutations or order submission were performed because verification must not alter the user account or place a real purchase; those command implementations remain the unchanged official release bytecode and their complete option surfaces are covered by smoke tests.